### PR TITLE
Enable affinity for CloudControllerManager Depoyment.

### DIFF
--- a/charts/cloud-controller-manager/Chart.yaml
+++ b/charts/cloud-controller-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloud-controller-manager
 description: A Helm chart for Kubernetes
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: 1.1.0
 sources:
   - https://github.com/Leaseweb/cloudstack-kubernetes-provider

--- a/charts/cloud-controller-manager/templates/deploy.yaml
+++ b/charts/cloud-controller-manager/templates/deploy.yaml
@@ -40,6 +40,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if gt (len .Values.nodeSelector) 0 }}
       nodeSelector: 
         {{ toYaml .Values.nodeSelector | nindent 8 }}

--- a/charts/cloud-controller-manager/values.yaml
+++ b/charts/cloud-controller-manager/values.yaml
@@ -79,7 +79,7 @@ tolerations:
   - key: "node.kubernetes.io/not-ready"
     effect: "NoExecute"
 
-## Set custom affinity rules to the Cloud Controller Manaegr instance
+## Set custom affinity rules to the Cloud Controller Manager instance
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 ##
 affinity: {}

--- a/charts/cloud-controller-manager/values.yaml
+++ b/charts/cloud-controller-manager/values.yaml
@@ -79,6 +79,11 @@ tolerations:
   - key: "node.kubernetes.io/not-ready"
     effect: "NoExecute"
 
+## Set custom affinity rules to the Cloud Controller Manaegr instance
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+##
+affinity: {}
+
 # Set security settings for the controller pods
 # For all available options, see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
 podSecurityContext:


### PR DESCRIPTION
With this PR we can set affinities for CloudControllerManager deployments, this is needed as we are using deployment objects and we want to have more than one replicas.