### PR TITLE
fix(chart): Don't hardcode version in values.yaml

### DIFF
--- a/charts/cloud-controller-manager/Chart.yaml
+++ b/charts/cloud-controller-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloud-controller-manager
 description: CloudStack Cloud Controller Manager Helm chart
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: 1.3.0
 sources:
   - https://github.com/Leaseweb/cloudstack-kubernetes-provider

--- a/charts/cloud-controller-manager/templates/deploy.yaml
+++ b/charts/cloud-controller-manager/templates/deploy.yaml
@@ -51,7 +51,7 @@ spec:
       serviceAccountName: {{ .Values.serviceAccountName }}
       containers:
         - name: cloudstack-cloud-controller-manager
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           args:
             - --v={{ .Values.logVerbosityLevel }}
             - --cloud-config=$(CLOUD_CONFIG)

--- a/charts/cloud-controller-manager/values.yaml
+++ b/charts/cloud-controller-manager/values.yaml
@@ -30,7 +30,8 @@ commonAnnotations: {}
 # Image repository name and tag
 image:
   repository: "ghcr.io/leaseweb/cloudstack-kubernetes-provider"
-  tag: "1.2.1"
+  # Overrides the image tag whose default is {{ .Chart.AppVersion }}
+  tag: ""
 
 # Additional containers which are run before the app containers are started.
 extraInitContainers: []


### PR DESCRIPTION
This PR fixes a hardcoded version in values.yaml. It now defaults to `.Chart.AppVersion`.