### PR TITLE
feat: add kubernetes ipmode support via annotation

### DIFF
--- a/deploy/ingress-sample/nginx-ingress-controller-patch.yml
+++ b/deploy/ingress-sample/nginx-ingress-controller-patch.yml
@@ -24,7 +24,8 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
   annotations:
-    service.beta.kubernetes.io/cloudstack-load-balancer-proxy-protocol: enabled
+    service.beta.kubernetes.io/cloudstack-load-balancer-proxy-protocol: "true"
+    service.beta.kubernetes.io/cloudstack-load-balancer-ip-mode: Proxy # or VIP
 spec:
   type: LoadBalancer
   selector:

--- a/deploy/ingress-sample/traefik-ingress-controller.yml
+++ b/deploy/ingress-sample/traefik-ingress-controller.yml
@@ -20,7 +20,8 @@ kind: Service
 metadata:
   name: traefik
   annotations:
-    service.beta.kubernetes.io/cloudstack-load-balancer-proxy-protocol: enabled
+    service.beta.kubernetes.io/cloudstack-load-balancer-proxy-protocol: "true"
+    service.beta.kubernetes.io/cloudstack-load-balancer-ip-mode: Proxy # or VIP
 spec:
   type: LoadBalancer
   ports:


### PR DESCRIPTION
Added optional support to configure ipMode on LoadBalancer service, since this feature is GA starting with Kubernetes v1.32.

It allows us to properly handle proxy protocol on CloudStack. Without this setting (ipMode: VIP by default) pods inside cluster can't access ingress resources via CloudStack loadbalancer with proxy protocol enabled.

User can set manually those mode by using annotation on service:

```yaml
service.beta.kubernetes.io/cloudstack-load-balancer-ip-mode: Proxy # or VIP
```

Would be great if we could release it as 1.4.0 anytime soon!